### PR TITLE
New comparison price

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,14 @@
 export { SignedOrder } from '@0x/order-utils';
 export { serverRoutes } from './router';
-export { FirmQuote, RFQTFirmQuote, RFQMFirmQuote, TakerRequest, IndicativeQuote, RFQTIndicativeQuote, RFQMIndicativeQuote, Quoter, SubmitReceipt, SubmitRequest } from './types';
+export {
+    FirmQuote,
+    RFQTFirmQuote,
+    RFQMFirmQuote,
+    TakerRequest,
+    IndicativeQuote,
+    RFQTIndicativeQuote,
+    RFQMIndicativeQuote,
+    Quoter,
+    SubmitReceipt,
+    SubmitRequest,
+} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,5 @@ export {
     Quoter,
     SubmitReceipt,
     SubmitRequest,
+    TakerRequestQueryParams,
 } from './types';

--- a/src/request_parser.ts
+++ b/src/request_parser.ts
@@ -36,18 +36,20 @@ export const parseTakerRequest = (req: Pick<express.Request, 'headers' | 'query'
         };
 
         let takerRequest: TakerRequest;
-        if (query.sellAmountBaseUnits) {
+        if (query.sellAmountBaseUnits !== undefined && query.buyAmountBaseUnits === undefined) {
             takerRequest = {
                 ...takerRequestBase,
                 sellAmountBaseUnits: new BigNumber(query.sellAmountBaseUnits),
             };
-        } else if (query.buyAmountBaseUnits) {
+        } else if (query.buyAmountBaseUnits !== undefined && query.sellAmountBaseUnits === undefined) {
             takerRequest = {
                 ...takerRequestBase,
                 buyAmountBaseUnits: new BigNumber(query.buyAmountBaseUnits),
             };
         } else {
-            throw new Error('"buyAmountBaseUnits" and "sellAmountBaseUnits" are mutually exclusive');
+            throw new Error(
+                'A request must specify either a "buyAmountBaseUnits" or a "sellAmountBaseUnits" (but not both).',
+            );
         }
         return { isValid: true, takerRequest };
     }

--- a/src/request_parser.ts
+++ b/src/request_parser.ts
@@ -8,7 +8,8 @@ import * as takerRequestSchema from './schemas/taker_request_schema.json';
 import { SubmitRequest, TakerRequest } from './types';
 
 type ParsedTakerRequest = { isValid: true; takerRequest: TakerRequest } | { isValid: false; errors: string[] };
-export const parseTakerRequest = (req: express.Request): ParsedTakerRequest => {
+
+export const parseTakerRequest = (req: Pick<express.Request, 'headers' | 'query'>): ParsedTakerRequest => {
     const query = req.query;
 
     // Create schema validator
@@ -32,6 +33,7 @@ export const parseTakerRequest = (req: express.Request): ParsedTakerRequest => {
             apiKey,
             takerAddress: query.takerAddress,
             canMakerControlSettlement,
+            comparisonPrice: query.comparisonPrice ? new BigNumber(query.comparisonPrice) : undefined,
         };
 
         const takerRequest: TakerRequest = query.sellAmountBaseUnits

--- a/src/request_parser.ts
+++ b/src/request_parser.ts
@@ -5,12 +5,12 @@ import * as express from 'express';
 import { ZERO_EX_API_KEY_HEADER_STRING } from './constants';
 import * as submitRequestSchema from './schemas/submit_request_schema.json';
 import * as takerRequestSchema from './schemas/taker_request_schema.json';
-import { SubmitRequest, TakerRequest } from './types';
+import { SubmitRequest, TakerRequest, TakerRequestQueryParams } from './types';
 
 type ParsedTakerRequest = { isValid: true; takerRequest: TakerRequest } | { isValid: false; errors: string[] };
 
 export const parseTakerRequest = (req: Pick<express.Request, 'headers' | 'query'>): ParsedTakerRequest => {
-    const query = req.query;
+    const query: TakerRequestQueryParams = req.query;
 
     // Create schema validator
     const schemaValidator = new SchemaValidator();
@@ -23,10 +23,9 @@ export const parseTakerRequest = (req: Pick<express.Request, 'headers' | 'query'
         if (typeof apiKey !== 'string') {
             apiKey = undefined;
         }
-        let canMakerControlSettlement = query.canMakerControlSettlement;
-        if (typeof canMakerControlSettlement !== 'boolean') {
-            canMakerControlSettlement = undefined;
-        }
+
+        // Querystring values are always returned as strings, therefore a boolean must be parsed as string.
+        const canMakerControlSettlement = query.canMakerControlSettlement === 'true' ? true : undefined;
         const takerRequestBase = {
             sellTokenAddress: query.sellTokenAddress,
             buyTokenAddress: query.buyTokenAddress,
@@ -36,9 +35,20 @@ export const parseTakerRequest = (req: Pick<express.Request, 'headers' | 'query'
             comparisonPrice: query.comparisonPrice ? new BigNumber(query.comparisonPrice) : undefined,
         };
 
-        const takerRequest: TakerRequest = query.sellAmountBaseUnits
-            ? { ...takerRequestBase, sellAmountBaseUnits: new BigNumber(query.sellAmountBaseUnits) }
-            : { ...takerRequestBase, buyAmountBaseUnits: new BigNumber(query.buyAmountBaseUnits) };
+        let takerRequest: TakerRequest;
+        if (query.sellAmountBaseUnits) {
+            takerRequest = {
+                ...takerRequestBase,
+                sellAmountBaseUnits: new BigNumber(query.sellAmountBaseUnits),
+            };
+        } else if (query.buyAmountBaseUnits) {
+            takerRequest = {
+                ...takerRequestBase,
+                buyAmountBaseUnits: new BigNumber(query.buyAmountBaseUnits),
+            };
+        } else {
+            throw new Error('"buyAmountBaseUnits" and "sellAmountBaseUnits" are mutually exclusive');
+        }
         return { isValid: true, takerRequest };
     }
 

--- a/src/schemas/taker_request_schema.json
+++ b/src/schemas/taker_request_schema.json
@@ -9,6 +9,9 @@
         },
         "takerAddress": {
             "$ref": "/addressSchema"
+        },
+        "comparisonPrice": {
+            "$ref": "/numberSchema"
         }
     },
     "required": ["sellTokenAddress", "buyTokenAddress", "takerAddress"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export type TakerRequest = RequireOnlyOne<
         canMakerControlSettlement?: boolean;
         sellAmountBaseUnits?: BigNumber;
         buyAmountBaseUnits?: BigNumber;
+        comparisonPrice?: BigNumber;
     },
     'sellAmountBaseUnits' | 'buyAmountBaseUnits'
 >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,21 @@ export type TakerRequest = RequireOnlyOne<
     'sellAmountBaseUnits' | 'buyAmountBaseUnits'
 >;
 
+export type TakerRequestQueryParams = RequireOnlyOne<
+    {
+        // export interface TakerRequestQueryParams {
+        sellTokenAddress: string;
+        buyTokenAddress: string;
+        takerAddress: string;
+        sellAmountBaseUnits?: string;
+        buyAmountBaseUnits?: string;
+        comparisonPrice?: string;
+        canMakerControlSettlement?: string;
+        // };
+    },
+    'sellAmountBaseUnits' | 'buyAmountBaseUnits'
+>;
+
 export type RFQTIndicativeQuote = Pick<
     SignedOrder,
     'makerAssetData' | 'makerAssetAmount' | 'takerAssetData' | 'takerAssetAmount' | 'expirationTimeSeconds'

--- a/test/handlers_test.ts
+++ b/test/handlers_test.ts
@@ -4,8 +4,8 @@ import * as chai from 'chai';
 import * as HttpStatus from 'http-status-codes';
 import * as httpMocks from 'node-mocks-http';
 import * as TypeMoq from 'typemoq';
-import { ZERO_EX_API_KEY_HEADER_STRING } from '../src/constants';
 
+import { ZERO_EX_API_KEY_HEADER_STRING } from '../src/constants';
 import { generateApiKeyHandler, submitRequestHandler, takerRequestHandler } from '../src/handlers';
 import { parseTakerRequest } from '../src/request_parser';
 import { Quoter, SubmitRequest, TakerRequest } from '../src/types';
@@ -44,12 +44,12 @@ describe('parseTakerRequest', () => {
         const request = {
             query,
             headers: {
-                [ZERO_EX_API_KEY_HEADER_STRING]: '0xfoo'
+                [ZERO_EX_API_KEY_HEADER_STRING]: '0xfoo',
             },
-
         };
         const parsedRequest = parseTakerRequest(request);
         if (parsedRequest.isValid && parsedRequest.takerRequest.comparisonPrice) {
+            // tslint:disable-next-line: custom-no-magic-numbers
             expect(parsedRequest.takerRequest.comparisonPrice.toNumber()).to.eql(320.12);
         } else {
             expect.fail('Parsed request is not valid or comparisonPrice was not parsed correctly');
@@ -67,7 +67,7 @@ describe('parseTakerRequest', () => {
         const request = {
             query,
             headers: {
-                [ZERO_EX_API_KEY_HEADER_STRING]: '0xfoo'
+                [ZERO_EX_API_KEY_HEADER_STRING]: '0xfoo',
             },
         };
         const parsedRequest = parseTakerRequest(request);
@@ -84,7 +84,7 @@ describe('parseTakerRequest', () => {
         const request = {
             query,
             headers: {
-                [ZERO_EX_API_KEY_HEADER_STRING]: '0xfoo'
+                [ZERO_EX_API_KEY_HEADER_STRING]: '0xfoo',
             },
         };
         const parsedRequest = parseTakerRequest(request);
@@ -93,7 +93,7 @@ describe('parseTakerRequest', () => {
         } else {
             expect.fail('Parsed request is not valid');
         }
-    })
+    });
 });
 
 describe('api key handler', () => {
@@ -217,7 +217,7 @@ describe('taker request handler', () => {
                 sellTokenAddress: takerRequest.sellTokenAddress,
                 buyAmountBaseUnits: takerRequest.buyAmountBaseUnits.toString(),
                 takerAddress: takerRequest.takerAddress,
-                canMakerControlSettlement: takerRequest.canMakerControlSettlement,
+                canMakerControlSettlement: takerRequest.canMakerControlSettlement.toString(),
             },
         });
         const resp = httpMocks.createResponse();


### PR DESCRIPTION
- Adds the new `comparisonPrice` optional parameter
- Fixed an issue with `canMakerControlSettlement` - Querystring values are always returned as strings, therefore a boolean must be parsed as string.
- Added the type `TakerRequestQueryParams` so that it can be used in monorepo
- unit tests
- linting