### PR TITLE
response should not need to contain the version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@0x/quote-server",
-    "version": "3.0.0",
+    "version": "4.0.1",
     "description": "RFQ Quote server",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -44,8 +44,8 @@ export const takerRequestHandler = async (
             ? quoter.fetchFirmQuoteAsync(takerRequest)
             : quoter.fetchIndicativeQuoteAsync(takerRequest);
 
-    const response = await responsePromise;
-    if (response && response.protocolVersion !== takerRequest.protocolVersion) {
+    const { protocolVersion, response } = await responsePromise;
+    if (protocolVersion !== takerRequest.protocolVersion) {
         console.error('Response and request protocol versions do not match');
         return res
             .status(HttpStatus.NOT_IMPLEMENTED)
@@ -53,7 +53,6 @@ export const takerRequestHandler = async (
             .end();
     }
     const result = response ? res.status(HttpStatus.OK).json(response) : res.status(HttpStatus.NO_CONTENT);
-
     return result.end();
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,7 @@ export {
     V4RFQIndicativeQuote,
     V4RFQFirmQuote,
     V4SignedRfqOrder,
+    VersionedQuote,
+    IndicativeQuoteResponse,
+    FirmQuoteResponse,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,10 +70,9 @@ export type V4RFQIndicativeQuote = Pick<
     'makerToken' | 'makerAmount' | 'takerToken' | 'takerAmount' | 'expiry'
 >;
 
-type IndicativeQuoteResponse =
+export type IndicativeQuoteResponse =
     | VersionedQuote<'3', V3RFQIndicativeQuote>
-    | VersionedQuote<'4', V4RFQIndicativeQuote>
-    | undefined;
+    | VersionedQuote<'4', V4RFQIndicativeQuote>;
 
 // Firm quotes, similar pattern
 export interface V3RFQFirmQuote {
@@ -84,7 +83,7 @@ export interface V4RFQFirmQuote {
     signedOrder: V4SignedRfqOrder;
 }
 
-type FirmQuoteResponse = VersionedQuote<'3', V3RFQFirmQuote> | VersionedQuote<'4', V4RFQFirmQuote> | undefined;
+export type FirmQuoteResponse = VersionedQuote<'3', V3RFQFirmQuote> | VersionedQuote<'4', V4RFQFirmQuote>;
 
 // Implement quoter that is version agnostic
 export interface Quoter {

--- a/test/handlers_test.ts
+++ b/test/handlers_test.ts
@@ -325,7 +325,7 @@ describe('taker request handler', () => {
         await takerRequestHandler('firm', quoter.object, req, resp);
 
         expect(resp._getStatusCode()).to.eql(HttpStatus.OK);
-        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(expectedResponse)));
+        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(expectedResponse.response)));
 
         quoter.verifyAll();
     });
@@ -362,7 +362,7 @@ describe('taker request handler', () => {
         await takerRequestHandler('firm', quoter.object, req, resp);
 
         expect(resp._getStatusCode()).to.eql(HttpStatus.OK);
-        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(expectedResponse)));
+        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(expectedResponse.response)));
 
         quoter.verifyAll();
     });
@@ -406,7 +406,7 @@ describe('taker request handler', () => {
         await takerRequestHandler('indicative', quoter.object, req, resp);
 
         expect(resp._getStatusCode()).to.eql(HttpStatus.OK);
-        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(indicativeQuote)));
+        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(indicativeQuote.response)));
 
         quoter.verifyAll();
     });
@@ -414,7 +414,9 @@ describe('taker request handler', () => {
         const quoter = TypeMoq.Mock.ofType<Quoter>(undefined, TypeMoq.MockBehavior.Strict);
         quoter
             .setup(async q => q.fetchIndicativeQuoteAsync(fakeV3TakerRequest))
-            .returns(async () => undefined)
+            .returns(async () => {
+                return { protocolVersion: '3', response: undefined };
+            })
             .verifiable(TypeMoq.Times.once());
 
         const req = httpMocks.createRequest({
@@ -439,7 +441,9 @@ describe('taker request handler', () => {
         const quoter = TypeMoq.Mock.ofType<Quoter>(undefined, TypeMoq.MockBehavior.Strict);
         quoter
             .setup(async q => q.fetchFirmQuoteAsync(fakeV3TakerRequest))
-            .returns(async () => undefined)
+            .returns(async () => {
+                return { protocolVersion: '3', response: undefined };
+            })
             .verifiable(TypeMoq.Times.once());
 
         const req = httpMocks.createRequest({
@@ -511,7 +515,7 @@ describe('taker request handler', () => {
         await takerRequestHandler('firm', quoter.object, req, resp);
 
         expect(resp._getStatusCode()).to.eql(HttpStatus.OK);
-        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(expectedResponse)));
+        expect(resp._getJSONData()).to.eql(JSON.parse(JSON.stringify(expectedResponse.response)));
 
         quoter.verifyAll();
     });


### PR DESCRIPTION
Just 1 major change here:

in order for this code to be backwards compatible with the current 0x API, we should not return the version in the response. We return a `VersionedResponse` in `fetchFirmQuoteAsync` and `fetchIndicativeQuoteAsync` so that we can ensure that the response if for the right protocol version, however, we then should return the same response format without version so that this can be backwards compatible