### PR TITLE
Make nesting depth consistent

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -75,12 +75,10 @@ export type IndicativeQuoteResponse =
     | VersionedQuote<'4', V4RFQIndicativeQuote>;
 
 // Firm quotes, similar pattern
-export interface V3RFQFirmQuote {
-    signedOrder: V3SignedOrder;
-}
+export type V3RFQFirmQuote = V3SignedOrder;
 
-export interface V4RFQFirmQuote {
-    signedOrder: V4SignedRfqOrder;
+export interface V4RFQFirmQuote extends V4RfqOrder {
+    signature: V4Signature;
 }
 
 export type FirmQuoteResponse = VersionedQuote<'3', V3RFQFirmQuote> | VersionedQuote<'4', V4RFQFirmQuote>;

--- a/test/handlers_test.ts
+++ b/test/handlers_test.ts
@@ -300,9 +300,7 @@ describe('taker request handler', () => {
     it('should defer to quoter and return response for firm quote', async () => {
         const quoter = TypeMoq.Mock.ofType<Quoter>(undefined, TypeMoq.MockBehavior.Strict);
         const expectedResponse: VersionedQuote<'3', V3RFQFirmQuote> = {
-            response: {
-                signedOrder: fakeV3Order,
-            },
+            response: fakeV3Order,
             protocolVersion: '3',
         };
         quoter
@@ -332,9 +330,7 @@ describe('taker request handler', () => {
     it('should succeed without an API key if `canMakerControlSettlement` is set to `true` when requesting a firm quote', async () => {
         const quoter = TypeMoq.Mock.ofType<Quoter>(undefined, TypeMoq.MockBehavior.Strict);
         const expectedResponse: VersionedQuote<'3', V3RFQFirmQuote> = {
-            response: {
-                signedOrder: fakeV3Order,
-            },
+            response: fakeV3Order,
             protocolVersion: '3',
         };
         const takerRequest = {
@@ -488,9 +484,7 @@ describe('taker request handler', () => {
     it('should handle a valid v4 request', async () => {
         const quoter = TypeMoq.Mock.ofType<Quoter>(undefined, TypeMoq.MockBehavior.Strict);
         const expectedResponse: VersionedQuote<'4', V4RFQFirmQuote> = {
-            response: {
-                signedOrder: fakeV4Order,
-            },
+            response: fakeV4Order,
             protocolVersion: '4',
         };
         quoter


### PR DESCRIPTION
This PR makes response types more consistent. 

Previously:
```
// Indicative quote
{ response: Partial<SignedOrder>, protocolVersion: Version }

// Firm quote
{ response: { signedOrder: SignedOrder }, protocolVersion: Version }
```

Now:
```
// Indicative quote
{ response: Partial<SignedOrder>, protocolVersion: Version }

// Firm quote
{ response: SignedOrder, protocolVersion: Version }
```